### PR TITLE
breaking(action): rename `change` event to `visibilitychange`

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,6 +6,6 @@ interface VisibilityChangeDetail {
 
 declare namespace svelte.JSX {
   interface HTMLProps {
-    onchange?: (event: CustomEvent<VisibilityChangeDetail>) => void;
+    onvisibilitychange?: (event: CustomEvent<VisibilityChangeDetail>) => void;
   }
 }

--- a/src/visibility-change.js
+++ b/src/visibility-change.js
@@ -8,7 +8,9 @@ export function visibilityChange(element) {
     const hidden = state === "hidden";
 
     element.dispatchEvent(
-      new CustomEvent("change", { detail: { state, visible, hidden } })
+      new CustomEvent("visibilitychange", {
+        detail: { state, visible, hidden },
+      })
     );
   };
 

--- a/tests/visibility-change.test.svelte
+++ b/tests/visibility-change.test.svelte
@@ -4,7 +4,7 @@
 
 <div
   use:visibilityChange
-  on:change={(e) => {
+  on:visibilitychange={(e) => {
     console.log(e.detail);
   }}
 />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "target": "es2017",
     "types": ["svelte"]
   },
-  "include": ["src/*", "tests/*"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
This renames the action event to "visibilitychange" to avoid clashing with the native "change" event.