### PR TITLE
refactor(types): use `DocumentVisibilityState` to type `state` prop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Run svelte-check
+      - name: Run unit tests
         run: |
           yarn
           yarn test

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The action only dispatches a "change" event with the same `event.detail` signatu
 
 <div
   use:visibilityChange
-  on:change={({ detail }) => {
+  on:visibilitychange={({ detail }) => {
     console.log(detail.state); // "visible" | "hidden"
     console.log(detail.visible); // boolean
     console.log(detail.hidden); // boolean

--- a/src/VisibilityChange.svelte
+++ b/src/VisibilityChange.svelte
@@ -1,14 +1,14 @@
 <script>
   /**
-   * Determine the current visibility state of the document
-   * @type {"visible" | "hidden"}
+   * The current visibility state of the document.
+   * @type {DocumentVisibilityState}
    */
   export let state = undefined;
 
-  /** `true` if the page is visible */
+  /** `true` if the page is visible ("focused"). */
   export let visible = false;
 
-  /** `true` if the page is not visible (i.e., "blurred") */
+  /** `true` if the page is not visible ("blurred"). */
   export let hidden = false;
 
   import { onMount, createEventDispatcher, tick } from "svelte";

--- a/src/VisibilityChange.svelte.d.ts
+++ b/src/VisibilityChange.svelte.d.ts
@@ -1,21 +1,21 @@
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
-export type VisibilityState = "visible" | "hidden";
+export type VisibilityState = DocumentVisibilityState;
 
 export interface VisibilityChangeProps {
   /**
-   * Determine the current visibility state of the document
+   * The current visibility state of the document.
    */
   state?: VisibilityState;
 
   /**
-   * `true` if the page is visible
+   * `true` if the page is visible ("focused").
    * @default false
    */
   visible?: boolean;
 
   /**
-   * `true` if the page is not visible (i.e., "blurred")
+   * `true` if the page is not visible ("blurred").
    * @default false
    */
   hidden?: boolean;
@@ -25,23 +25,23 @@ export default class extends SvelteComponentTyped<
   VisibilityChangeProps,
   {
     /**
-     * Dispatched whenever the browser tab is focused or blurred
+     * Dispatched whenever the page is focused or blurred.
      */
     change: CustomEvent<{
-      state: VisibilityState;
+      state: DocumentVisibilityState;
       visible: boolean;
       hidden: boolean;
     }>;
 
     /**
-     * Dispatched when the browser tab is focused
+     * Dispatched when the browser tab is focused.
      */
-    visible: CustomEvent<any>;
+    visible: CustomEvent<null>;
 
     /**
-     * Dispatched when the browser tab is blurred
+     * Dispatched when the browser tab is blurred.
      */
-    hidden: CustomEvent<any>;
+    hidden: CustomEvent<null>;
   },
   {}
 > {}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,11 +1,11 @@
-interface VisibilityChangeDetail {
-  state: "visible" | "hidden";
-  visible: boolean;
-  hidden: boolean;
-}
-
 declare namespace svelte.JSX {
   interface HTMLProps {
-    onvisibilitychange?: (event: CustomEvent<VisibilityChangeDetail>) => void;
+    onvisibilitychange?: (
+      event: CustomEvent<{
+        state: DocumentVisibilityState;
+        visible: boolean;
+        hidden: boolean;
+      }>
+    ) => void;
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,2 +1,2 @@
 export { default } from "./VisibilityChange.svelte";
-export { visibilityChange, OnChangeEvent } from "./visibility-change";
+export { visibilityChange } from "./visibility-change";

--- a/src/visibility-change.d.ts
+++ b/src/visibility-change.d.ts
@@ -1,5 +1,3 @@
 import type { Action } from "svelte/action";
 
-type VisibilityChangeAction = Action<HTMLElement>;
-
-export const visibilityChange: VisibilityChangeAction;
+export const visibilityChange: Action<HTMLElement>;

--- a/src/visibility-change.js
+++ b/src/visibility-change.js
@@ -1,7 +1,7 @@
 /**
- * @param {HTMLElement} element
+ * @type {import ("svelte/action").Action<HTMLElement>}
  */
-export function visibilityChange(element) {
+export const visibilityChange = (element) => {
   const change = () => {
     const state = document.visibilityState;
     const visible = state === "visible";
@@ -15,10 +15,9 @@ export function visibilityChange(element) {
   };
 
   document.addEventListener("visibilitychange", change);
-
   return {
     destroy() {
       document.removeEventListener("visibilitychange", change);
     },
   };
-}
+};


### PR DESCRIPTION
Use the existing `DocumentVisibilityState` type instead of manually typing `"hidden" | "visible"`.

**Refactor**

- use `DocumentVisibilityState` to type `state` prop